### PR TITLE
Upgrade to 0.4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ group: deprecated-2017Q3
 services:
   - postgresql
 
+addons:
+  postgresql: "9.4"
+
 env:
   - TOX_ENV=py36-django-18
   - TOX_ENV=py35-django-18
@@ -34,3 +37,13 @@ script: tox -e $TOX_ENV
 
 after_success:
   - codecov -e TOX_ENV
+
+deploy:
+  provider: pypi
+  user: $PYPI_USER
+  password:
+    secure: $PYPI_PASSWORD
+  on:
+    repo: jjkester/django-auditlog
+    branch: stable
+    condition: $TOX_ENV = py36-django-20

--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ Contribute
 ----------
 
 If you have great ideas for Auditlog, or if you like to improve something, feel free to fork this repository and/or create a pull request. I'm open for suggestions. If you like to discuss something with me (about Auditlog), please open an issue.
+
+Releases
+--------
+
+1. Make sure all tests on `master` are green.
+2. Create a new branch `vX.Y.Z` from master for that specific release.
+3. Bump versions in `setup.py` and `docs/source/conf.py` (docs have 2 places where the versions need to be changed!)
+4. Pull request `vX.Y.Z` -> `stable`. Merging policy is very strict. This triggers a new release.
+5. Pull request `stable` -> `master`. Now everything is back in sync.
+
+Opening a pull request from `master` directly to `stable` is discouraged as `master` may be updated while the PR is open, thus changing the contents of the release.
+

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,4 @@ coverage==4.3.4
 tox>=1.7.0
 codecov>=2.0.0
 django-multiselectfield==0.1.8
-psycopg2
+psycopg2-binary


### PR DESCRIPTION
To solve too many warning in testing, we have to upgrade this lib. 

This PR will upgrade from `0.4.2` to `0.4.5` 

Release note can be found here: https://github.com/jjkester/django-auditlog/releases